### PR TITLE
Update loader to understand "vars" property

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const loader = function(content)
   }
 
   if (config.vars) {
-    Object.assign(vars, config.config);
+      Object.assign(vars, JSON.parse(config.vars));
   }
 
   function jsToSass (obj) {


### PR DESCRIPTION
Loader incorrectly referenced config.config when config.vars is set. This fix allows a user to pass custom vars directly in their webpack config like so:

```
const susyDebug = DEBUG ? 'show' : 'hide';
const sassVarsConfig = querystring.stringify({
   files: [
      path.resolve(helpers.paths.appRoot + '/styles/sass-js-variables.js')
      // path.resolve(__dirname, '/path/to/breakpoints.js'), // JS
      // path.resolve(__dirname, '/path/to/colors.json'), // JSON
   ],
   vars: [JSON.stringify({'susyDebug': susyDebug})],
});
```
Then, your loader should look something like:
```
loaders: ['css?sourceMap', 'postcss', 'sass?sourceMap', '@epegzz/sass-vars-loader?' + sassVarsConfig],
```