### PR TITLE
Add support for printing strings with quotes

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var opts = {
+  prefix: '',
+  suffix: '',
+  suffixLastItem: true,
+};
+
+function objToValue(obj, opts) {
+  var keys = Object.keys(obj);
+  var fields = keys.map(function(key) {
+    var value = formatValue(obj[key]);
+    return opts.prefix + key + ":" + value;
+  });
+
+  var result = fields.join(opts.suffix + "\n");
+  if (opts.suffixLastItem) {
+    return result + opts.suffix;
+  }
+
+  return result;
+}
+
+function formatValue(value) {
+  if (value instanceof Array) {
+    var result = value.map(function(v) {
+      return formatValue(v);
+    });
+    return result.join(', ');
+  }
+
+  if (typeof value === 'object') {
+    var opts = {
+      prefix: '',
+      suffix: ',',
+      suffixLastItem: false,
+    }
+    return '(\n' + objToValue(value, opts) + '\n)';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}
+
+module.exports = objToValue;
+

--- a/convert.test.js
+++ b/convert.test.js
@@ -1,0 +1,80 @@
+var convert = require('./convert');
+
+test('Convert string', function() {
+  var obj = {test: 'value'};
+  var opts = {
+    prefix: "$",
+    suffix: ";",
+    suffixLastItem: true,
+  };
+  var out = '$test:value;';
+  expect(convert(obj, opts)).toBe(out);
+});
+
+test('Convert string with quotes', function() {
+  var obj = {test: '"value"'};
+  var opts = {
+    prefix: "$",
+    suffix: ";",
+    suffixLastItem: true,
+  };
+  var out = '$test:"value";';
+  expect(convert(obj, opts)).toBe(out);
+});
+
+
+test('Convert number', function() {
+  var obj = {test: 5};
+  var opts = {
+    prefix: "$",
+    suffix: ";",
+    suffixLastItem: true,
+  };
+  var out = '$test:5;';
+  expect(convert(obj, opts)).toBe(out);
+});
+
+test('Convert array', function() {
+  var obj = {test: [1, 2]};
+  var opts = {
+    prefix: "$",
+    suffix: ";",
+    suffixLastItem: true,
+  };
+  var out = '$test:1, 2;';
+  expect(convert(obj, opts)).toBe(out);
+});
+
+test('Convert object: simple', function() {
+  var obj = {test: {a: 1}};
+  var opts = {
+    prefix: "$",
+    suffix: ";",
+    suffixLastItem: true,
+  };
+  var out = '$test:(\na:1\n);';
+  expect(convert(obj, opts)).toBe(out);
+});
+
+test('Convert object: multi value', function() {
+  var obj = {test: {a: 1, b: 2}};
+  var opts = {
+    prefix: "$",
+    suffix: ";",
+    suffixLastItem: true,
+  };
+  var out = '$test:(\na:1,\nb:2\n);';
+  expect(convert(obj, opts)).toBe(out);
+});
+
+test('Convert object: nested', function() {
+  var obj = {test: {a: 1, b: 2, c: {d: 4}}};
+  var opts = {
+    prefix: "$",
+    suffix: ";",
+    suffixLastItem: true,
+  };
+  var out = '$test:(\na:1,\nb:2,\nc:(\nd:4\n)\n);';
+  expect(convert(obj, opts)).toBe(out);
+});
+

--- a/convert.test.js
+++ b/convert.test.js
@@ -1,80 +1,80 @@
-var convert = require('./convert');
+const convert = require('./convert');
 
 test('Convert string', function() {
-  var obj = {test: 'value'};
-  var opts = {
+  const obj = {test: 'value'};
+  const opts = {
     prefix: "$",
     suffix: ";",
     suffixLastItem: true,
   };
-  var out = '$test:value;';
+  const out = '$test:value;';
   expect(convert(obj, opts)).toBe(out);
 });
 
 test('Convert string with quotes', function() {
-  var obj = {test: '"value"'};
-  var opts = {
+  const obj = {test: '"value"'};
+  const opts = {
     prefix: "$",
     suffix: ";",
     suffixLastItem: true,
   };
-  var out = '$test:"value";';
+  const out = '$test:"value";';
   expect(convert(obj, opts)).toBe(out);
 });
 
 
 test('Convert number', function() {
-  var obj = {test: 5};
-  var opts = {
+  const obj = {test: 5};
+  const opts = {
     prefix: "$",
     suffix: ";",
     suffixLastItem: true,
   };
-  var out = '$test:5;';
+  const out = '$test:5;';
   expect(convert(obj, opts)).toBe(out);
 });
 
 test('Convert array', function() {
-  var obj = {test: [1, 2]};
-  var opts = {
+  const obj = {test: [1, 2]};
+  const opts = {
     prefix: "$",
     suffix: ";",
     suffixLastItem: true,
   };
-  var out = '$test:1, 2;';
+  const out = '$test:1, 2;';
   expect(convert(obj, opts)).toBe(out);
 });
 
 test('Convert object: simple', function() {
-  var obj = {test: {a: 1}};
-  var opts = {
+  const obj = {test: {a: 1}};
+  const opts = {
     prefix: "$",
     suffix: ";",
     suffixLastItem: true,
   };
-  var out = '$test:(\na:1\n);';
+  const out = '$test:(\na:1\n);';
   expect(convert(obj, opts)).toBe(out);
 });
 
 test('Convert object: multi value', function() {
-  var obj = {test: {a: 1, b: 2}};
-  var opts = {
+  const obj = {test: {a: 1, b: 2}};
+  const opts = {
     prefix: "$",
     suffix: ";",
     suffixLastItem: true,
   };
-  var out = '$test:(\na:1,\nb:2\n);';
+  const out = '$test:(\na:1,\nb:2\n);';
   expect(convert(obj, opts)).toBe(out);
 });
 
 test('Convert object: nested', function() {
-  var obj = {test: {a: 1, b: 2, c: {d: 4}}};
-  var opts = {
+  const obj = {test: {a: 1, b: 2, c: {d: 4}}};
+  const opts = {
     prefix: "$",
     suffix: ";",
     suffixLastItem: true,
   };
-  var out = '$test:(\na:1,\nb:2,\nc:(\nd:4\n)\n);';
+  const out = '$test:(\na:1,\nb:2,\nc:(\nd:4\n)\n);';
   expect(convert(obj, opts)).toBe(out);
 });
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const loaderUtils = require('loader-utils');
 const fs = require('fs');
+const convert = require('./convert');
 
 const loader = function(content)
 {
@@ -35,30 +36,12 @@ const loader = function(content)
   }
 
   function jsToSass (obj) {
-    // Convert object root properties into sass variables
-    var sass = '';
-    for (var key in obj) {
-      sass += '$' + key + ':' + JSON.stringify(obj[key]) + ';\n';
-    }
-
-    // Store string values (so they remain unaffected)
-    var storedStrings = [];
-    sass = sass.replace(/(["'])(?:(?=(\\?))\2.)*?\1/g, function (str) {
-
-      var id = '___JTS' + storedStrings.length;
-      storedStrings.push({id: id, value: str});
-      return id;
-    });
-
-    // Convert js lists and objects into sass lists and maps
-    sass = sass.replace(/[{\[]/g, '(').replace(/[}\]]/g, ')');
-
-    // Put string values back (now that we're done converting)
-    // Remove quotes from the value
-    storedStrings.forEach(function (str) {
-      sass = sass.replace(str.id, str.value.replace(/['"]+/g, ''));
-    });
-
+    const opts = {
+      prefix: '$',
+      suffix: ';',
+      suffixLastItem: true,
+    };
+    var sass = convert(obj, opts);
     return sass;
   }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.3",
   "author": "Daniel Schäfer <epegzz@gmail.com>",
   "description": "A SASS vars loader for Webpack. Load global SASS vars from JS/JSON files or from Webpack config.",
-  "files": ["index.js"],
+  "files": [
+    "index.js"
+  ],
   "dependencies": {
     "loader-utils": "~0.2.11"
   },
@@ -11,7 +13,21 @@
     "type": "git",
     "url": "https://github.com/epegzz/sass-vars-loader"
   },
+  "scripts": {
+    "test": "jest",
+    "watch-test": "jest --watch"
+  },
   "keywords": [
-    "scss", "sass", "js", "json", "vars", "variables", "webpack", "loader"
-  ]
+    "scss",
+    "sass",
+    "js",
+    "json",
+    "vars",
+    "variables",
+    "webpack",
+    "loader"
+  ],
+  "devDependencies": {
+    "jest": "^18.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "author": "Daniel Schäfer <epegzz@gmail.com>",
   "description": "A SASS vars loader for Webpack. Load global SASS vars from JS/JSON files or from Webpack config.",
   "files": [
-    "index.js"
+    "index.js",
+    "convert.js"
   ],
   "dependencies": {
     "loader-utils": "~0.2.11"


### PR DESCRIPTION
The conversion logic is rewritten so it supports string with quotes.

It's also now in it's own file (convert.js) and with tests (convert.test.js)