### PR TITLE
Update loader-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "main": "src/index.js",
   "dependencies": {
-    "loader-utils": "~0.2.11"
+    "loader-utils": "~1.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const loader = function(content)
 {
   this.cacheable();
 
-  const config = loaderUtils.getLoaderConfig(this, 'sassVars');
+  const config = loaderUtils.getOptions(this);
 
   const vars = {};
   if (config.files) {


### PR DESCRIPTION
Update loader utils to remove loaderUtils.parseQuery() deprecation warning

see https://github.com/webpack/loader-utils/issues/56

