### PR TITLE
Remove quotes from strings

### DIFF
--- a/src/utils/__snapshots__/convertJsToSass.test.js.snap
+++ b/src/utils/__snapshots__/convertJsToSass.test.js.snap
@@ -42,10 +42,6 @@ exports[`With sass syntax converts simple simple 1`] = `"$it: (1, 2)"`;
 
 exports[`With sass syntax converts string 1`] = `"$it: value"`;
 
-exports[`With sass syntax converts string and adds quotes for leading spaces 1`] = `"$it: \\"  value\\""`;
-
-exports[`With sass syntax converts string and adds quotes for leading zero 1`] = `"$it: \\"012345\\""`;
-
 exports[`With sass syntax converts string with double quotes 1`] = `"$it: 'value'"`;
 
 exports[`With sass syntax converts string with single quotes 1`] = `"$it: \\"value\\""`;
@@ -91,10 +87,6 @@ exports[`With scss syntax converts simple object 1`] = `"$it: (a: 1);"`;
 exports[`With scss syntax converts simple simple 1`] = `"$it: (1, 2);"`;
 
 exports[`With scss syntax converts string 1`] = `"$it: value;"`;
-
-exports[`With scss syntax converts string and adds quotes for leading spaces 1`] = `"$it: \\"  value\\";"`;
-
-exports[`With scss syntax converts string and adds quotes for leading zero 1`] = `"$it: \\"012345\\";"`;
 
 exports[`With scss syntax converts string with double quotes 1`] = `"$it: 'value';"`;
 

--- a/src/utils/convertJsToSass.js
+++ b/src/utils/convertJsToSass.js
@@ -10,12 +10,6 @@ function formatNestedObject(obj, syntax) {
   return keys.map(key => `${key}: ${formatValue(obj[key], syntax)}`).join(', ')
 }
 
-function withQuotesIfNecessary(value) {
-  const hasQuotes = /^['"](\n|.)*['"]$/gm.test(value)
-  const requiresQuotes = /^[0 ]/.test(value)
-  return hasQuotes || !requiresQuotes ? value : `"${value}"`
-}
-
 function formatValue(value, syntax) {
   if (value instanceof Array) {
     return `(${value.map(formatValue).join(', ')})`
@@ -26,7 +20,7 @@ function formatValue(value, syntax) {
   }
 
   if (typeof value === 'string') {
-    return withQuotesIfNecessary(value)
+    return value
   }
 
   return JSON.stringify(value)

--- a/src/utils/convertJsToSass.test.js
+++ b/src/utils/convertJsToSass.test.js
@@ -2,8 +2,6 @@ const convertJsToSass = require('./convertJsToSass')
 
 const testCases = [
   { name: 'converts string', input: { it: 'value' } },
-  { name: 'converts string and adds quotes for leading zero', input: { it: '012345' } },
-  { name: 'converts string and adds quotes for leading spaces', input: { it: '  value' } },
   { name: 'converts multi line string', input: { it: 'line1\nline2' } },
   { name: 'converts string with single quotes', input: { it: '"value"' } },
   { name: 'converts string with double quotes', input: { it: "'value'" } },


### PR DESCRIPTION
Actually I don't understand why the string quoting is needed. If one wants quotes around the string he can just add them in the string.

Also, the previous code broke box shadows like `0 2px 0 1px rgba(0, 0, 0, 0.1)` because of the leading zero.