### PR TITLE
Repin TypeScript version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "loader-utils": "^1.2.3",
     "require-from-string": "^2.0.2",
-    "typescript": "^3.5.3"
+    "typescript": ">=3.5.3"
   },
   "devDependencies": {
     "codecov": "^3.5.0",


### PR DESCRIPTION
TypeScript does not follow semantic versioning; 4.0 was not a breaking change from 3.9. The version range in this project's package.json means that projects running on TypeScript 4.x cannot de-duplicate the very large TypeScript dependency. This PR updates the version range from a "minor version" pin to a "greater than or equal to" pin, which reflects the original intent in light of TypeScript's versioning practices.